### PR TITLE
Add missing break operator.

### DIFF
--- a/lwgsm/src/lwgsm/lwgsm_int.c
+++ b/lwgsm/src/lwgsm/lwgsm_int.c
@@ -1412,6 +1412,8 @@ lwgsmi_process_sub_cmd(lwgsm_msg_t* msg, uint8_t* is_ok, uint16_t* is_error) {
                     }
                 }
             }
+            break;
+
             default:
                 break;
         }


### PR DESCRIPTION
This will suppress linter warning about missing operator in switch-case.